### PR TITLE
Add Conditional for Paginator Partial

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -11,4 +11,6 @@ permalink: "{% if paged.index > 0 %}page/{{ paged.index + 1 }}/{% endif %}index.
     {% include "partials/post-grid.njk" %}
 </div>
 
+{% if collections.posts.length > site.paginate %}
 {% include "partials/paginator.njk" %}
+{% endif %}

--- a/src/tags.njk
+++ b/src/tags.njk
@@ -18,4 +18,6 @@ eleventyComputed:
     {% include "partials/post-grid.njk" %}
 </div>
 
+{% if collections.tagList[paged.name] > site.paginate %}
 {% include "partials/paginator.njk" %}
+{% endif %}


### PR DESCRIPTION
## Description 
Added a conditional that will not render the paginator partial unless the number of posts or posts with a certain tag exceeds the paginate number set in the '_data/site.js' file. This change is applied to index.njk and partials/paginator.njk.

## Why? 
I think this is an appropriate addition as the option to change pages shouldn't be present until the user can change pages. This eliminates unnecessary page elements, and improves the simplistic aspect.  

### Tag Page
<img width="1792" alt="Tag List Page" src="https://user-images.githubusercontent.com/10472448/103323121-38e13d80-49f6-11eb-9e24-8bfb17421ea8.png">

### Page with Paginator
<img width="1792" alt="Page with Paginator" src="https://user-images.githubusercontent.com/10472448/103323123-3aab0100-49f6-11eb-828a-3c6210298914.png">

### Page without Paginator
<img width="1792" alt="Page without Paginator" src="https://user-images.githubusercontent.com/10472448/103323126-3c74c480-49f6-11eb-9d94-3ed6b99e35f7.png">
