### PR TITLE
Refactor link rendering: Add 'active' class to links pointing to the …

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -7,7 +7,7 @@
         </div>
         <nav id="menu" class="order-last md:order-none items-center flex-grow w-full md:w-auto md:flex hidden mt-2 md:mt-0">
             {% for item in menu %}
-            <a href="{{ item.url | url }}" {% if item.newTab %}target="_blank" rel="noopener" {% endif %}class="block mt-4 md:inline-block md:mt-0 font-medium text-slate-700 hover:text-teal-600 text-base mr-4">{{ item.label }}</a>
+            <a href="{{ item.url | url }}" {% if item.newTab %}target="_blank" rel="noopener" {% endif %}class="block mt-4 md:inline-block md:mt-0 font-medium text-slate-700 hover:text-teal-600 text-base mr-4{% if item.url == page.filePathStem %} active{% endif %}">{{ item.label }}</a>
             {% endfor %}
         </nav>
         <form id="search" action="{{ '/search' | url }}" class="order-last sm:order-none flex-grow items-center justify-end hidden sm:block mt-6 sm:mt-0">


### PR DESCRIPTION
This change adds an 'active' class to links that point to the current page to provide visual feedback to users when they are on the current page.
It can be done by adding "text-teal-600" class as well, although it is less flexible 